### PR TITLE
Fix max_results from json learning

### DIFF
--- a/lib/logstash/inputs/azure_blob_storage.rb
+++ b/lib/logstash/inputs/azure_blob_storage.rb
@@ -475,7 +475,7 @@ end
 def learn_encapsulation
     # From one file, read first block and last block to learn head and tail
     begin
-        blobs = @blob_client.list_blobs(container, { maxresults: 3, prefix: @prefix})
+        blobs = @blob_client.list_blobs(container, { max_results: 3, prefix: @prefix})
         blobs.each do |blob|
             unless blob.name == registry_path
               begin


### PR DESCRIPTION
As per http://azure.github.io/azure-storage-ruby/Azure/Storage/Blob/Container.html#list_blobs-instance_method

Our logstash instance keeps crashing because of the blob storage feed (it works fine when we disable it). It took a long while to figure out why, but we believe this is due to this fix, which causes the JSON learning routine to spin pretty much forever at each startup and eventually die exhausting resources.

It's hard to tell because the logs aren't very verbose, but this seems promising!