### PR TITLE
Reuse HTTP connections to Azure Storage

### DIFF
--- a/lib/logstash/inputs/azure_blob_storage.rb
+++ b/lib/logstash/inputs/azure_blob_storage.rb
@@ -291,8 +291,7 @@ public
                         end
                     end
                     @registry.store(name, { :offset => size, :length => file[:length] })
-                    # TODO add input plugin option to prevent connection cache
-                    @blob_client.client.reset_agents!
+                    
                     #@logger.info("name #{name} size #{size} len #{file[:length]}")
                     # if stop? good moment to stop what we're doing
                     if stop?


### PR DESCRIPTION
Cache reset is not needed anymore. Reset was added when underlying client created and cached agents per URL.

Since then agents are cached per host [^1] and was configured to use persistent adapter [^2]. So it is beneficial to reuse agents.

[^1]: https://github.com/Azure/azure-storage-ruby/commit/d102f9b4ca45b564d3cd0e2e3a5e77966c66b703

[^2]: https://github.com/Azure/azure-storage-ruby/commit/a550e5465bd9263371ded778cea6b244fed673ac